### PR TITLE
Fix hang on exit for robotpy test and robotpy sim

### DIFF
--- a/src/pykit/loggedrobot.py
+++ b/src/pykit/loggedrobot.py
@@ -80,7 +80,13 @@ class LoggedRobot(IterativeRobotBase):
                 else:
                     hal.updateNotifierAlarm(self.notifier, int(self._nextCycleUs))
 
-                    currentTimeOrStopped, status = hal.waitForNotifierAlarm(self.notifier)
+                    currentTimeOrStopped, status = hal.waitForNotifierAlarm(
+                        self.notifier
+                    )
+                    if status != 0:
+                        raise RuntimeError(
+                            f"Error waiting for notifier alarm: status {status}"
+                        )
                     if currentTimeOrStopped == 0:
                         break
                 self._nextCycleUs += self._periodUs


### PR DESCRIPTION
This fixes #13 and the known problem of hanging on a `robotpy sim` exit.

I've tested it via `robotpy test` and `robotpy sim` on my Mac. I have not tested it on Windows, Linux, or a roborio.

-Mike