### PR TITLE
Get sim, sim replay, deploy and deploy replay to work.

### DIFF
--- a/src/pykit/loggedrobot.py
+++ b/src/pykit/loggedrobot.py
@@ -35,7 +35,7 @@ class LoggedRobot(IterativeRobotBase):
         # Because in "robotpy test" this code starts at time 0
         # and hal.waitForNotifierAlarm returns (current_time_or_stopped, status)
         # with current_time_or_stopped assigned to 0 when hal.stopNotifier is called
-        # or when the the current time is 0, and hal.stopNotifier is signal to
+        # or when the current time is 0, and hal.stopNotifier is signal to
         # exit the infinite loop, the stop is prematurely detected at time 0.
         # Force the program to wait until self._periodUs for the first periodic loop
         # so that current_time_or_stopped will contain a non-zero current time and the
@@ -58,6 +58,14 @@ class LoggedRobot(IterativeRobotBase):
         This method replaces the standard `IterativeRobotBase.startCompetition`
         to inject logging and precise timing control.
         """
+
+        Logger.startReciever()
+        startCompetitionTime = RobotController.getFPGATime()
+        Logger.periodicAfterUser(startCompetitionTime, 0)
+        stop = Logger.periodicBeforeUser()
+        if stop:
+            Logger.end()
+            return
         self.robotInit()
 
         if self.isSimulation():
@@ -67,8 +75,6 @@ class LoggedRobot(IterativeRobotBase):
         Logger.periodicAfterUser(self.initEnd, 0)
         print("Robot startup complete!")
         hal.observeUserProgramStarting()
-
-        Logger.startReciever()
 
         while True:
             # Wait for next cycle using HAL notifier for precise timing
@@ -93,7 +99,7 @@ class LoggedRobot(IterativeRobotBase):
 
             # Run logger pre-user code (load inputs from log or sensors)
             periodicBeforeStart = RobotController.getFPGATime()
-            Logger.periodicBeforeUser()
+            stop = Logger.periodicBeforeUser()
 
             # Execute user periodic code and measure timing
             userCodeStart = RobotController.getFPGATime()
@@ -104,3 +110,7 @@ class LoggedRobot(IterativeRobotBase):
             Logger.periodicAfterUser(
                 userCodeEnd - userCodeStart, userCodeStart - periodicBeforeStart
             )
+            if stop:
+                break
+
+        Logger.end()

--- a/src/pykit/logger.py
+++ b/src/pykit/logger.py
@@ -246,18 +246,16 @@ class Logger:
 
         :return: The current timestamp in microseconds.
         """
-        if cls.isReplay():
-            return cls.entry.getTimestamp()
-        # RobotController.getFPGATime may be untyped; ensure int
-        return int(RobotController.getFPGATime())
+        return cls.entry.getTimestamp()
 
     @classmethod
-    def periodicBeforeUser(cls):
+    def periodicBeforeUser(cls) -> bool:
         """
         Called periodically before the user's robot code.
         This method updates the log table with new data, either from the replay source
         or from the live robot hardware.
         """
+        stop = False
         cls.cycleCount += 1
         if cls.running:
             entryUpdateStart = RobotController.getFPGATime()
@@ -273,9 +271,7 @@ class Logger:
                         print(
                             "[ERROR] This robot did not start properly, is the replay logfile from PyKit?"
                         )
-                    else:
-                        cls.end()
-                    raise SystemExit(0)
+                    stop = True
 
             dsStart = RobotController.getFPGATime()
             # In replay mode, simulate driver station inputs from log
@@ -302,6 +298,7 @@ class Logger:
                 "Logger/DashboardInputsMS",
                 (dashboardInputEnd - dashboardInputStart) / 1000.0,
             )
+        return stop
 
     @classmethod
     def periodicAfterUser(cls, userCodeLength: int, periodicBeforeLength: int):

--- a/src/pykit/wpilog/wpilogwriter.py
+++ b/src/pykit/wpilog/wpilogwriter.py
@@ -36,7 +36,7 @@ class WPILOGWriter(LogDataReciever):
     folder: str
     filename: str
     randomIdentifier: str
-    dsAttachedTime: int = 0
+    dsAttachedTime: float = 0.0
     autoRename: bool
     logDate: datetime.datetime | None
     logMatchText: str
@@ -172,7 +172,7 @@ class WPILOGWriter(LogDataReciever):
                     ) > 5 or RobotBase.isSimulation():
                         self.logDate = datetime.datetime.now()
                 else:
-                    self.dsAttachedTime = 0
+                    self.dsAttachedTime = 0.0
 
                 matchType: MatchType
                 match table.get("DriverStation/MatchType", 0):


### PR DESCRIPTION
Suggest that we develop some tests to go along with this change.  

This pull request has the changes I made to PyKit to get this robotpy program: https://github.com/spiresfrc9106/spiresRobot2026/tree/41762640c5f6642aa6aab3dc169e8a447ac63d61

so that it would do `robotpy test` of an auto drive out sim and and replay: See https://github.com/spiresfrc9106/spiresRobot2026/blob/41762640c5f6642aa6aab3dc169e8a447ac63d61/tests/replay_test.py#L82

Note that changes to pyfrc to get the test to work are here: https://github.com/spiresfrc9106/spiresRobot2026/blob/41762640c5f6642aa6aab3dc169e8a447ac63d61/examples/pyfrc/pyfrc/test_support/pytest_isolated_tests_plugin.py#L248

This repo is currently running a local version of pykit here: https://github.com/spiresfrc9106/spiresRobot2026/tree/41762640c5f6642aa6aab3dc169e8a447ac63d61/pykit

The repo is able to do simulated replays of deployed robot pykit log files that play back the same.

I've been using this tool to compare realoutputs and replayoutputs portions of a replayed _sim.wpilog file.:  https://github.com/spiresfrc9106/spiresRobot2026/blob/41762640c5f6642aa6aab3dc169e8a447ac63d61/tools/find_replay_divergence.py

Again, perhaps we should add some tests similar to `robotpy test` of pykit similar to the one in tests/replay_test.py

-Mike

